### PR TITLE
mimemagic version fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,9 @@ gem 'passenger', '~> 6.0' # production app server
 gem 'bootsnap', require: false
 gem 'sassc', '2.1.0'
 
+# mimemagic 0.3.5 version fix
+gem 'mimemagic', github: 'mimemagicrb/mimemagic', ref: '01f92d86d15d85cfd0f20dabd025dcbd36a8a60f'
+
 # AR like interface to static data hash based classes
 gem 'active_hash'
 


### PR DESCRIPTION
Issue:
```
Step 25/35 : RUN /bin/bash -l -c "bundle install --system" &&  passenger-config install-standalone-runtime &&  passenger start --runtime-check-only
 ---> Running in 1056d526c40c
mesg: ttyname failed: Inappropriate ioctl for device
[DEPRECATED] The `--system` flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use `bundle config set --local system 'true'`, and stop using this flag
Don't run Bundler as root. Bundler can ask for sudo if it is needed, and
installing your bundle as root will break this application for all non-root
users on this machine.
Fetching https://github.com/m0n9oose/omniauth_openid_connect
Fetching https://github.com/37signals/mail_view.git
Fetching https://github.com/criticaljuncture/klarlack.git
Fetching https://github.com/criticaljuncture/calendar_helper.git
Fetching https://github.com/criticaljuncture/cachebar.git
Fetching gem metadata from https://rubygems.org/.........
Resolving dependencies......
Your bundle is locked to mimemagic (0.3.5) from rubygems repository
https://rubygems.org/ or installed locally, but that version can no longer be
found in that source. That means the author of mimemagic (0.3.5) has removed it.
You'll need to update your bundle to a version other than mimemagic (0.3.5) that
hasn't been removed in order to install.
```

Solution
```
gem 'mimemagic', github: 'mimemagicrb/mimemagic', ref: '01f92d86d15d85cfd0f20dabd025dcbd36a8a60f'
```